### PR TITLE
add HostWorkingDir, improve package and env handling 

### DIFF
--- a/commands/web/gum
+++ b/commands/web/gum
@@ -5,5 +5,6 @@
 ## Usage: gum
 ## Example: "ddev gum"
 ## ExecRaw: true
+## HostWorkingDir: true
 
 gum "$@"

--- a/config.gum.yaml
+++ b/config.gum.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+webimage_extra_packages: [gum]
+web_environment:
+  - COLORTERM=${COLORTERM}

--- a/install.yaml
+++ b/install.yaml
@@ -2,5 +2,5 @@ name: gum
 
 project_files:
 - commands/web/gum
-- web-build/pre.Dockerfile.gum
 - config.gum.yaml
+- web-build/pre.Dockerfile.gum

--- a/install.yaml
+++ b/install.yaml
@@ -1,5 +1,6 @@
-name: ddev-gum
+name: gum
 
 project_files:
 - commands/web/gum
-- web-build/Dockerfile.ddev-gum
+- web-build/pre.Dockerfile.gum
+- config.gum.yaml

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,9 +1,9 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/ddev-gum
+  export TESTDIR=~/tmp/tes-gum
   mkdir -p $TESTDIR
-  export PROJNAME=ddev-gum
+  export PROJNAME=test-gum
   export DDEV_ADDON=Morgy93/ddev-gum
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,7 +1,7 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/tes-gum
+  export TESTDIR=~/tmp/test-gum
   mkdir -p $TESTDIR
   export PROJNAME=test-gum
   export DDEV_ADDON=Morgy93/ddev-gum

--- a/web-build/pre.Dockerfile.gum
+++ b/web-build/pre.Dockerfile.gum
@@ -3,6 +3,3 @@
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | tee /etc/apt/sources.list.d/charm.list
-# https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/#build-time-environment-variables
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests gum
-ENV COLORTERM=truecolor


### PR DESCRIPTION
Hi, thanks for this add on and for introducing me to gum.

Forgive  is this PR is a bit opinionated, hope you'd appreciate the changes:

- Added `HostWorkingDir: true` to the command

This is so things like `ddev gum choose $(ls)` works. It's a command that I would think it should run relative to where you are, not always from the root of the project.

- gum instead of ddev-gum on most places/filenames

This has been a recent change, if you look at things like https://github.com/ddev/ddev-solr/blob/main/install.yaml the name is without ddev, same applies to dockerfiles like https://github.com/ddev/ddev-platformsh/blob/main/web-build/Dockerfile.platformsh.

- Renamed the dockerfile to pre.Dockerfile.gum and improved it a bit

As ddev supports adding extra package, by doing it as a pre.Dockerfile it allows ddev to do its thing (apt-get update and all that) without your dockerfile needing to do it twice. More performant build and less to manage.

Also I removed COLORTERM, rather than hardcode it on the Dockerfile, better addit as an envnironment variable that can use your own COLORTERM env var.

- Added config.gum.yaml

This allows all of the above to work.
