### PR TITLE
Update README for older versions of DDEV

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ddev add-on get Morgy93/ddev-gum
 ddev restart
 ```
 
-> **Note**
+> [!NOTE]
 > For DDEV versions prior to v1.23.5, use `ddev get` instead of `ddev add-on get`.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ YouTube Shorts: [Gum: Write Glamorous Shell Scripts](https://www.youtube.com/wat
 ## Installation
 
 ```shell
-ddev get Morgy93/ddev-gum
+ddev add-on get Morgy93/ddev-gum
 ddev restart
 ```
+
+> **Note**
+> For DDEV versions prior to v1.23.5, use `ddev get` instead of `ddev add-on get`.
 
 ## Usage
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -35,9 +35,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DDEV_ADDON}
+  echo "# ddev add-on get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DDEV_ADDON}
   ddev restart >/dev/null
   health_checks
 }
-


### PR DESCRIPTION
Update installation command and add note for older versions in `README.md`.

* Update the installation command to use `ddev add-on get` instead of `ddev get`.
* Add a note for older versions to use `ddev get` instead of `ddev add-on get`.

Update `tests/test.bats` to use `ddev add-on get` command.

* Update the `ddev get` command to `ddev add-on get` in the `install from directory` test.
* Update the `ddev get` command to `ddev add-on get` in the `install from release` test.

