### PR TITLE
move to OpenForgeProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
     <h1 align="center">ddev-gum</h1>
 </div>
 
-[![tests](https://github.com/Morgy93/ddev-gum/actions/workflows/tests.yml/badge.svg)](https://github.com/Morgy93/ddev-gum/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/OpenForgeProject/ddev-gum/actions/workflows/tests.yml/badge.svg)](https://github.com/OpenForgeProject/ddev-gum/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## What is Gum?
 
 > A tool for glamorous shell scripts. Leverage the power of [Bubbles](https://github.com/charmbracelet/bubbles) and [Lip Gloss](https://github.com/charmbracelet/lipgloss) in your scripts and aliases without writing any Go code!
 >
-> ![gum](https://github.com/Morgy93/ddev-gum/assets/7961978/426f48a5-f02e-423e-a894-ca54bd2cd0d1)
+> ![gum](https://github.com/OpenForgeProject/ddev-gum/assets/7961978/426f48a5-f02e-423e-a894-ca54bd2cd0d1)
 
 For more information, see the [official repository](https://github.com/charmbracelet/gum) or visit <https://charm.sh/>.
 
@@ -25,7 +25,7 @@ YouTube Shorts: [Gum: Write Glamorous Shell Scripts](https://www.youtube.com/wat
 ## Installation
 
 ```shell
-ddev add-on get Morgy93/ddev-gum
+ddev add-on get OpenForgeProject/ddev-gum
 ddev restart
 ```
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,7 +4,7 @@ setup() {
   export TESTDIR=~/tmp/test-gum
   mkdir -p $TESTDIR
   export PROJNAME=test-gum
-  export DDEV_ADDON=Morgy93/ddev-gum
+  export DDEV_ADDON=OpenForgeProject/ddev-gum
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"


### PR DESCRIPTION
This pull request includes changes to update the project references from `Morgy93` to `OpenForgeProject` in the `README.md` and `tests/test.bats` files.

Updates to project references:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R17): Updated the badge and image URLs to point to the `OpenForgeProject` repository instead of `Morgy93`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Changed the installation command to use the `OpenForgeProject` repository.
* [`tests/test.bats`](diffhunk://#diff-a2bb1b04da80b87de17520a6aac3664b1cafdec2b6431697f15968522708a47cL7-R7): Modified the `DDEV_ADDON` environment variable to reference `OpenForgeProject/ddev-gum` instead of `Morgy93/ddev-gum`.